### PR TITLE
Stop display update timer in preheat when home pressed

### DIFF
--- a/PizzaOvenUI/HomeButton.qml
+++ b/PizzaOvenUI/HomeButton.qml
@@ -26,6 +26,7 @@ Rectangle {
             onClicked: SequentialAnimation {
                     ScriptAction {
                         script: {
+                            homeButton.clicked();
                             autoShutoff.reset();
                             rootWindow.maxPreheatTimer.stop();
                             rootWindow.cookTimer.stop();
@@ -37,7 +38,6 @@ Rectangle {
                             halfTimeRotateAlertOccurred = false;
                             finalCheckAlertOccurred = false;
                             pizzaDoneAlertOccurred = false;
-                            homeButton.clicked();
                             forceScreenTransition(Qt.resolvedUrl("Screen_MainMenu.qml"));
                         }
                     }

--- a/PizzaOvenUI/PizzaOvenUI.pro.user
+++ b/PizzaOvenUI/PizzaOvenUI.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.0.1, 2019-08-14T17:13:41. -->
+<!-- Written by QtCreator 4.0.1, 2019-09-03T14:43:27. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -209,27 +209,27 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">RemoteLinux.DirectUploadStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedFiles">
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Select.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Cancel.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Increase.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmMid.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmLow.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOff.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_UnavailableTouch.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_Notification.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CycleComplete.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_On.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Off.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOff.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePost.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOn.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePre.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOn.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Touch.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Select.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Debug/PizzaOvenUI</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Cancel.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmMid.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CycleComplete.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmLow.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOn.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOn.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Off.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePost.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_Notification.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Increase.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_On.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOff.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Touch.wav</value>
       </valuelist>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedHosts">
        <value type="QString">raspberrypi.local</value>
@@ -239,16 +239,16 @@
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
+       <value type="QString">raspberrypi.local</value>
+       <value type="QString">raspberrypi.local</value>
+       <value type="QString">raspberrypi.local</value>
        <value type="QString">192.168.7.3</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
+       <value type="QString">raspberrypi.local</value>
+       <value type="QString">raspberrypi.local</value>
+       <value type="QString">raspberrypi.local</value>
        <value type="QString">192.168.7.3</value>
-       <value type="QString">raspberrypi.local</value>
-       <value type="QString">raspberrypi.local</value>
-       <value type="QString">raspberrypi.local</value>
-       <value type="QString">raspberrypi.local</value>
-       <value type="QString">raspberrypi.local</value>
-       <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
@@ -269,8 +269,8 @@
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/</value>
+       <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
@@ -302,26 +302,26 @@
       </valuelist>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedTimes">
        <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-09-01T17:02:24</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2016-09-01T17:02:24</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T11:27:56</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-09-01T17:02:24</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
+       <value type="QDateTime">2016-09-01T17:02:24</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
       </valuelist>
       <value type="bool" key="RemoteLinux.GenericDirectUploadStep.IgnoreMissingFiles">false</value>
       <value type="bool" key="RemoteLinux.GenericDirectUploadStep.Incremental">true</value>

--- a/PizzaOvenUI/Screen_Preheating2Temp.qml
+++ b/PizzaOvenUI/Screen_Preheating2Temp.qml
@@ -168,9 +168,9 @@ Item {
         id: preheatingHomeButton
         needsAnimation: false
         onClicked: {
+            displayUpdateTimer.stop();
             lowerFrontAnimation.stop();
             upperFrontAnimation.stop();
-            displayUpdateTimer.stop();
         }
     }
 


### PR DESCRIPTION
Fixes race condition where a home button press would kill some timers which would cause a transition to "cooking" even though the oven was not preheated.
