### PR TITLE
Fix preheat display problem, no ding on preheat exit

### DIFF
--- a/PizzaOvenUI/PizzaOvenUI.pro.user
+++ b/PizzaOvenUI/PizzaOvenUI.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.0.1, 2019-12-10T08:09:43. -->
+<!-- Written by QtCreator 4.0.1, 2019-12-11T08:35:14. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -64,7 +64,7 @@
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Raspberry Pi</value>
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Raspberry Pi</value>
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{cd3169bf-c053-4186-8fe8-2756fdf4b3d2}</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">1</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
@@ -209,33 +209,35 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">RemoteLinux.DirectUploadStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedFiles">
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Cancel.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CycleComplete.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOn.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Release/PizzaOvenUI</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Cancel.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_On.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_Notification.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Off.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Debug/PizzaOvenUI</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmLow.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePost.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOff.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Release/PizzaOvenUI</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmMid.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOn.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePost.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Select.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Touch.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Increase.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOff.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOn.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Select.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Debug/PizzaOvenUI</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Touch.wav</value>
-       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePre.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_Notification.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePost.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOn.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePre.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_On.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOff.wav</value>
        <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_UnavailableTouch.wav</value>
+       <value type="QString">/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Off.wav</value>
       </valuelist>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedHosts">
        <value type="QString">raspberrypi.local</value>
+       <value type="QString">192.168.7.3</value>
+       <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
@@ -247,8 +249,6 @@
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">192.168.7.3</value>
-       <value type="QString">192.168.7.3</value>
-       <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
        <value type="QString">raspberrypi.local</value>
@@ -264,26 +264,26 @@
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
+       <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
        <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/sounds</value>
-       <value type="QString">/home/pi/</value>
        <value type="QString">/home/pi/sounds</value>
       </valuelist>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedSysroots">
@@ -313,30 +313,30 @@
        <value type="QString">/home/rob/raspi/sysroot</value>
       </valuelist>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedTimes">
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2019-10-14T15:23:26</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2019-10-14T15:23:25</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2019-10-14T15:23:25</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2019-10-14T15:23:25</value>
        <value type="QDateTime">2016-10-13T09:09:55</value>
        <value type="QDateTime">2016-09-01T17:02:24</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:55</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
-       <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T11:27:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2019-10-14T15:23:25</value>
+       <value type="QDateTime">2019-10-14T15:23:26</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
        <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2019-10-14T15:23:25</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2019-10-14T15:23:25</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:56</value>
+       <value type="QDateTime">2016-10-13T09:09:55</value>
       </valuelist>
       <value type="bool" key="RemoteLinux.GenericDirectUploadStep.IgnoreMissingFiles">false</value>
       <value type="bool" key="RemoteLinux.GenericDirectUploadStep.Incremental">true</value>

--- a/PizzaOvenUI/Screen_Preheating2Temp.qml
+++ b/PizzaOvenUI/Screen_Preheating2Temp.qml
@@ -95,7 +95,11 @@ Item {
             break;
         case "Cooking":
             preheatComplete = true;
-            forceScreenTransition(Qt.resolvedUrl("Screen_Cooking.qml"));
+            doExitCheck();
+            break;
+        case "PreheatStoneOnly":
+            upperTempLocked = false;
+            upperTemp = currentUpperMininumTemp;
             break;
         }
     }
@@ -253,7 +257,6 @@ Item {
 
     function doExitCheck() {
         if (screenExitAnimator.running) return;
-//        if ((upperTempLocked && lowerTempLocked) || !rootWindow.maxPreheatTimer.running || (localOvenState == "Cooking")) {
           if ((upperTempLocked && lowerTempLocked) || !rootWindow.maxPreheatTimer.running || (localOvenState == "Cooking")) {
             if (ovenState == "Idle") {
                 handleOvenStateMsg("Idle");

--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -155,7 +155,7 @@ Window {
 
     // some information
     property string controlVersion: "255.255.255.255"
-    property string uiVersion: "0.3.6"
+    property string uiVersion: "0.3.7"
     property string backendVersion: "255.255.255.255"
     property string interfaceVersion: "255.255.255.255"
     property string wifiMacId: ""


### PR DESCRIPTION
Changes:
- Reset temp latch and min temp display when the control state is stone preheat.  This allows the dome temp to ramp properly after previously being latched
- Play the chime when exiting preheat to cooking
- Bump version for release