### PR TITLE
Don't set `callServiceFailure` for Door Status messages

### DIFF
--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -113,11 +113,6 @@ Window {
     property int doorLatchState: 0
     property int doorCount: 0
     property int doorStatus: 0
-    onDoorStatusChanged: {
-        if (doorStatus == 1) {
-            callServiceFailure = true;
-        }
-    }
 
     property bool controlBoardCommsFailed: false
     onControlBoardCommsFailedChanged: {


### PR DESCRIPTION
We had a race condition involving the MC and the UI. Depending on what was sent first after the door input status because true, the UI might display the appropriate message and data, or it might display a blank failure screen without data. If the next message was the door status, the failure data would be blank; if it was the failures message then the screen would display the failure data. 

This change make it so that only the failures message from the MC can set `callServiceFailure` on the UI. 

@rbultman Could you make sure I'm merging into the correct branch here?