### PR TITLE
Remove clock display

### DIFF
--- a/PizzaOvenUI/PizzaOvenUI.pro.user
+++ b/PizzaOvenUI/PizzaOvenUI.pro.user
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.0.1, 2021-09-22T10:05:54. -->
+<!-- Written by QtCreator 4.0.3, 2021-12-13T15:35:18. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{7bd2f56a-bbe8-4bab-b452-628e7a8b9ca3}</value>
+  <value type="QByteArray">{4909e095-a271-4bf9-b897-539532ea9e24}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
@@ -61,14 +61,14 @@
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.6.1 GCC 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.6.1 GCC 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.6.2 GCC 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.6.2 GCC 64bit</value>
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.56.gcc_64_kit</value>
    <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Desktop_Qt_5_6_1_GCC_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -128,7 +128,7 @@
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Desktop_Qt_5_6_1_GCC_64bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -305,14 +305,14 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">PizzaOvenUI</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/rob/git/PizzaOvenRPiUI/PizzaOvenUI/PizzaOvenUI.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">PizzaOvenUI2</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/PizzaOvenUI.pro</value>
     <value type="bool" key="QmakeProjectManager.QmakeRunConfiguration.UseLibrarySearchPath">true</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">PizzaOvenUI.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory">/home/rob/pizzaOvenDevRoot/app</value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Desktop_Qt_5_6_1_GCC_64bit-Debug</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
@@ -326,74 +326,14 @@
  <data>
   <variable>ProjectExplorer.Project.Target.1</variable>
   <valuemap type="QVariantMap">
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Raspberry Pi</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Raspberry Pi</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{cd3169bf-c053-4186-8fe8-2756fdf4b3d2}</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Pi 3</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Pi 3</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{c11d13ce-74e5-4bd3-a1af-6c469238c8e5}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">2</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Debug</value>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">true</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">false</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
-      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
-    </valuemap>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
-      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
-    </valuemap>
-    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
-    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Debug</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
-    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
-    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
-   </valuemap>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -452,8 +392,8 @@
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/rob/git/PizzaOvenRPiUI/build-PizzaOvenUI-Raspberry_Pi-Profile</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -512,6 +452,66 @@
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">true</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">false</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
+    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+   </valuemap>
    <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
@@ -533,11 +533,111 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Upload files via SFTP</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">RemoteLinux.DirectUploadStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedFiles"/>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedHosts"/>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedRemotePaths"/>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedSysroots"/>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedTimes"/>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedFiles">
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Select.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOn.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_UnavailableTouch.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Touch.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOn.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_Notification.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Decrease.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Cancel.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmUrgent.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PowerOff.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_On.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePre.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CyclePost.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_CycleComplete.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Off.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_PressHoldOff.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmLow.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Passive_AlarmMid.wav</value>
+       <value type="QString">/home/ricksuel/git/PizzaOvenRPiUI/PizzaOvenUI/sounds/Monogram_Interact_Increase.wav</value>
+      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedHosts">
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+       <value type="QString">192.168.0.101</value>
+      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedRemotePaths">
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+       <value type="QString">/home/pi/app/sounds</value>
+      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedSysroots">
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+       <value type="QString">/home/ricksuel/raspi/sysroot</value>
+      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MaemoRunConfiguration.LastDeployedTimes">
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:31</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:31</value>
+       <value type="QDateTime">2021-12-13T15:02:31</value>
+       <value type="QDateTime">2021-12-13T15:02:31</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+       <value type="QDateTime">2021-12-13T15:02:30</value>
+      </valuelist>
       <value type="bool" key="RemoteLinux.GenericDirectUploadStep.IgnoreMissingFiles">false</value>
       <value type="bool" key="RemoteLinux.GenericDirectUploadStep.Incremental">true</value>
      </valuemap>

--- a/PizzaOvenUI/Screen_Cooldown.qml
+++ b/PizzaOvenUI/Screen_Cooldown.qml
@@ -37,11 +37,7 @@ Item {
                 }
             }
             else {
-                if (timeOfDayDisplayed) {
-                    forceScreenTransition(Qt.resolvedUrl("Screen_TimeOfDay.qml"));
-                } else {
-                    forceScreenTransition(Qt.resolvedUrl("Screen_Off.qml"));
-                }
+                forceScreenTransition(Qt.resolvedUrl("Screen_Off.qml"));
             }
             break;
         }

--- a/PizzaOvenUI/Screen_MainMenu.qml
+++ b/PizzaOvenUI/Screen_MainMenu.qml
@@ -28,11 +28,7 @@ Item {
         if (powerSwitch == 0) {
             screenExit();
             stackView.clear();
-            if (timeOfDayDisplayed) {
-                stackView.push({item: Qt.resolvedUrl("Screen_TimeOfDay.qml"), immediate:immediateTransitions});
-            } else {
-                stackView.push({item: Qt.resolvedUrl("Screen_Off.qml"), immediate:immediateTransitions});
-            }
+            stackView.push({item: Qt.resolvedUrl("Screen_Off.qml"), immediate:immediateTransitions});
         }
     }
 
@@ -96,11 +92,7 @@ Item {
                 script: {
                     screenExit();
                     stackView.clear();
-                    if (timeOfDayDisplayed) {
-                        stackView.push({item: Qt.resolvedUrl("Screen_TimeOfDay.qml"), immediate:immediateTransitions});
-                    } else {
-                        stackView.push({item: Qt.resolvedUrl("Screen_Off.qml"), immediate:immediateTransitions});
-                    }
+                    stackView.push({item: Qt.resolvedUrl("Screen_Off.qml"), immediate:immediateTransitions});
                 }
             }
         }

--- a/PizzaOvenUI/Screen_Settings2.qml
+++ b/PizzaOvenUI/Screen_Settings2.qml
@@ -83,7 +83,6 @@ Item {
         ListElement { name: "VOLUME"; screen: "Screen_SetVolume.qml" }
         ListElement { name: "DISPLAY BRIGHTNESS"; screen: "Screen_SetBrightness.qml" }
         ListElement { name: "ABOUT"; screen: "Screen_About.qml" }
-        ListElement { name: "TIME"; screen: "Screen_SettingsTime.qml" }
     }
 
     Tumbler {

--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -77,11 +77,7 @@ Window {
             sounds.powerOff.play();
             if (!callServiceFailure) {
                 console.log("The power switch is now off, transitioning to the off screen.");
-                if (timeOfDayDisplayed) {
-                    forceScreenTransition(Qt.resolvedUrl("Screen_TimeOfDay.qml"));
-                } else {
-                    forceScreenTransition(Qt.resolvedUrl("Screen_Off.qml"));
-                }
+                forceScreenTransition(Qt.resolvedUrl("Screen_Off.qml"));
             }
         }
     }
@@ -152,7 +148,6 @@ Window {
     property int screenOffsetX: appSettings.screenOffsetX
     property int screenOffsetY: appSettings.screenOffsetY
     property string timeOfDay: "12:00"
-    property bool timeOfDayDisplayed: appSettings.timeOfDayDisplayed
     property int smallTextSize: 32
     property int bigTextSize: 55
     property int titleTextSize: 18 * screenScale
@@ -355,11 +350,7 @@ Window {
                 appSettings.backlightOff = false;
                 if (appSettings.settingsInitialized) {
                     if (callServiceFailure == false) {
-                        if (timeOfDayDisplayed) {
-                            Qt.resolvedUrl("Screen_TimeOfDay.qml");
-                        } else {
-                            Qt.resolvedUrl("Screen_Off.qml");
-                        }
+                        Qt.resolvedUrl("Screen_Off.qml");
                     } else {
                         Qt.resolvedUrl("Screen_CallService.qml");
                     }

--- a/PizzaOvenUI/programSettings.cpp
+++ b/PizzaOvenUI/programSettings.cpp
@@ -20,7 +20,6 @@ const bool defaultRotatePizzaAlert = true;
 const bool defaultFinalCheckAlert = true;
 const bool defaultDoneAlert = true;
 const bool defaultDemoMode = true;
-const bool defaultTimeOfDayDisplayedState = false;
 
 extern QObject *appParentObj;
 bool backlightFileExists = false;
@@ -127,7 +126,6 @@ void ProgramSettings::loadSettingsFromJsonObject(const QJsonObject &settings)
     m_doneAlertEnabled = (settings.contains("doneAlertEnabled")) ? settings["doneAlertEnabled"].toBool() : defaultDoneAlert;
     m_demoModeState = (settings.contains("demoModeEnable")) ? settings["demoModeEnable"].toBool() : defaultDemoMode;
     m_demoModeState = (settings.contains("demoModeEnable")) ? settings["demoModeEnable"].toBool() : defaultDemoMode;
-    m_timeOfDayDisplayedState = (settings.contains("timeOfDayDisplayed")) ? settings["timeOfDayDisplayed"].toBool() : defaultTimeOfDayDisplayedState;
 }
 
 void ProgramSettings::storeSettingsToJsonObject(QJsonObject &settings) const
@@ -143,7 +141,6 @@ void ProgramSettings::storeSettingsToJsonObject(QJsonObject &settings) const
     settings["finalCheckAlertEnabled"] = m_finalCheckAlertEnabled;
     settings["doneAlertEnabled"] = m_doneAlertEnabled;
     settings["demoModeEnable"] = m_demoModeState;
-    settings["timeOfDayDisplayed"] = m_timeOfDayDisplayedState;
 }
 
 void ProgramSettings::initializeSettingsToDefaults(void)
@@ -161,7 +158,6 @@ void ProgramSettings::initializeSettingsToDefaults(void)
     m_finalCheckAlertEnabled = defaultFinalCheckAlert;
     m_doneAlertEnabled = defaultDoneAlert;
     m_demoModeState = defaultDemoMode;
-    m_timeOfDayDisplayedState = defaultTimeOfDayDisplayedState;
 }
 
 /*************** TOD Offset ***************/
@@ -177,19 +173,6 @@ void ProgramSettings::setTodOffset(int newOffset)
 int ProgramSettings::todOffset()
 {\
     return m_todOffset;
-}
-
-/*************** Time Of Day Displayed ***************/
-void ProgramSettings::setTimeOfDayDisplayState(bool displayed)
-{
-    m_timeOfDayDisplayedState = displayed;
-    emit timeOfDayDisplayedStateChanged();
-    saveSettings();
-}
-
-bool ProgramSettings::getTimeOfDayDisplayedState()
-{
-    return m_timeOfDayDisplayedState;
 }
 
 /*************** Screen Offset X ***************/

--- a/PizzaOvenUI/programSettings.h
+++ b/PizzaOvenUI/programSettings.h
@@ -13,7 +13,6 @@ class ProgramSettings : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int todOffset READ todOffset WRITE setTodOffset NOTIFY todOffsetChanged)
-    Q_PROPERTY(bool timeOfDayDisplayed READ getTimeOfDayDisplayedState WRITE setTimeOfDayDisplayState NOTIFY timeOfDayDisplayedStateChanged)
     Q_PROPERTY(int screenOffsetX READ getScreenOffsetX WRITE setScreenoffsetX NOTIFY screenOffsetXChanged)
     Q_PROPERTY(int screenOffsetY READ getScreenOffsetY WRITE setScreenoffsetY NOTIFY screenOffsetYChanged)
     Q_PROPERTY(bool settingsInitialized READ areSettingsInitialized WRITE intializeSettings NOTIFY initializationChanged)
@@ -35,8 +34,6 @@ public:
 
     void setTodOffset(int newOffset);
     int  todOffset();
-    void setTimeOfDayDisplayState(bool displayed);
-    bool getTimeOfDayDisplayedState();
     void setScreenoffsetX(int OffsetX);
     void setScreenoffsetY(int OffsetY);
     int  getScreenOffsetX();
@@ -81,7 +78,6 @@ signals:
 public slots:
 private:
     int m_todOffset;
-    bool m_timeOfDayDisplayedState;
     int m_screenXOffset;
     int m_screenYOffset;
     bool m_settingsInitialized;


### PR DESCRIPTION
Background:
Product management wants the time of day screen removed. This PR removes it.

Definition of done:
- [x] Remove "Time" from the settings display.
- [x] Remove references to the time screen from the code.


QA:
- [x] Verify that the time of day is gone using a gen 2 pizza oven.