### PR TITLE
Fix the food list "ghosting" issue

### DIFF
--- a/PizzaOvenUI/Screen_MainMenu.qml
+++ b/PizzaOvenUI/Screen_MainMenu.qml
@@ -45,24 +45,30 @@ Item {
         setMenuPositionFromFoodIndex();
     }
 
+    function loadTheFoodListIfEmpty() {
+        if (foodListModel.count == 0) {
+            var menuItems = menuSettings.json.menuItems;
+            var menuIndexes = menuSettings.json.menuOrder;
+
+            if (menuItems.length === menuIndexes.length) {
+                for(var i=0; i<menuItems.length; i++)  {
+                    foodListModel.append(menuItems[menuIndexes[i]]);
+                }
+            } else {
+                for(var i=0; i<menuItems.length; i++)  {
+                    foodListModel.append(menuItems[i]);
+                }
+            }
+        }
+    }
+
     function screenEntry() {
         backEnd.sendMessage("StopOven ");
         autoShutoff.stop();
         preheatComplete = false;
         console.log("Entering main menu screen.");
-        // load up the list
-        foodListModel.clear();
-        var menuItems = menuSettings.json.menuItems;
-        var menuIndexes = menuSettings.json.menuOrder;
-        if (menuItems.length === menuIndexes.length) {
-            for(var i=0; i<menuItems.length; i++)  {
-                foodListModel.append(menuItems[menuIndexes[i]]);
-            }
-        } else {
-            for(var i=0; i<menuItems.length; i++)  {
-                foodListModel.append(menuItems[i]);
-            }
-        }
+
+        loadTheFoodListIfEmpty();
 
         appSettings.backlightOff = false;
         if (powerSwitch == 0) {


### PR DESCRIPTION
**Bug Description:**
Occasionally, when scrolling through the food menu, there will be a glitch as shown here:
<img width="619" alt="Display_Ghosting" src="https://user-images.githubusercontent.com/5245531/146609842-effffc8d-21f7-4a38-89ae-9e5f2e7b5726.png">

**Steps to reproduce:**
1. Select a food item, and navigate to the cook settings screen for that item.
2. Press the home button and navigate back to the main screen.
3. Press the gear button and navigate to the settings screen.
4. Press the back button and navigate back to the main screen.
5. Press the gear button and navigate to the settings screen again.
6. Press the back button and navigate to the main screen again.
7. Scroll through the menu and it should ghost on the food item selected in step 1.

**Fix:**
I don't have a definitive answer for why this works, but I suspect there may be a bug in the version of Qt we are using. Ultimately, each time we go from any screen back to the home screen, the code was clearing and then rebuilding the food list that feeds the Tumbler object. There appears to be some issue with clearing and then populating the list/tumbler multiple times. 

This change will only populate the food list if it is empty. 

