### PR TITLE
Bug Fix - Mobile app always starts 'custom' cycles

### DIFF
--- a/PizzaOvenUI/BackEndConnection.qml
+++ b/PizzaOvenUI/BackEndConnection.qml
@@ -368,7 +368,8 @@ Item {
                 cookTime = msg.data.time;
                 sendMessage("WriteTimerSettingResponse id " + msg.data.id + " result success");
                 // The following line was causing strange things to happen. Removing it seems to fix the issue.
-                // utility.findPizzaTypeFromSettings();
+                console.log("Got cookTime from back end: " + cookTime + ". Attempting to find pizza type.");
+                utility.findPizzaTypeFromSettings();
             } else {
                 console.log("Got a message to set the timer setting, but request is invalid: " + JSON.stringify(msg.data));
                 sendMessage("WriteTimerSettingResponse id " + msg.data.id + " result failure");

--- a/PizzaOvenUI/BackEndConnection.qml
+++ b/PizzaOvenUI/BackEndConnection.qml
@@ -367,7 +367,8 @@ Item {
             if (msg.data.time && msg.data.time>=0 && msg.data.time<=65535) {
                 cookTime = msg.data.time;
                 sendMessage("WriteTimerSettingResponse id " + msg.data.id + " result success");
-                utility.findPizzaTypeFromSettings();
+                // The following line was causing strange things to happen. Removing it seems to fix the issue.
+                // utility.findPizzaTypeFromSettings();
             } else {
                 console.log("Got a message to set the timer setting, but request is invalid: " + JSON.stringify(msg.data));
                 sendMessage("WriteTimerSettingResponse id " + msg.data.id + " result failure");

--- a/PizzaOvenUI/Screen_AwaitStart.qml
+++ b/PizzaOvenUI/Screen_AwaitStart.qml
@@ -36,6 +36,13 @@ Item {
         localStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
     }
 
+    function update() {
+        rootWindow.displayedDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
+        rootWindow.displayedStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
+        localDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
+        localStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
+    }
+
     function cleanUpOnExit() {
         console.log("Exiting await start screen");
         console.log("Stopping all animations");

--- a/PizzaOvenUI/Screen_AwaitStart.qml
+++ b/PizzaOvenUI/Screen_AwaitStart.qml
@@ -30,17 +30,17 @@ Item {
         theCircle.animate();
         circleContent.animate();
         screenEntryAnimation.start();
-        rootWindow.displayedDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
-        rootWindow.displayedStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
-        localDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
-        localStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
+        rootWindow.displayedDomeTemp = upperFront.setTemp;
+        rootWindow.displayedStoneTemp = lowerFront.setTemp;
+        localDomeTemp = upperFront.setTemp;
+        localStoneTemp = lowerFront.setTemp;
     }
 
     function update() {
-        rootWindow.displayedDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
-        rootWindow.displayedStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
-        localDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
-        localStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
+        rootWindow.displayedDomeTemp = upperFront.setTemp;
+        rootWindow.displayedStoneTemp = lowerFront.setTemp;
+        localDomeTemp = upperFront.setTemp;
+        localStoneTemp = lowerFront.setTemp;
     }
 
     function cleanUpOnExit() {

--- a/PizzaOvenUI/Screen_Preheating2Temp.qml
+++ b/PizzaOvenUI/Screen_Preheating2Temp.qml
@@ -35,12 +35,16 @@ Item {
 
     property string localOvenState: "Preheat1"
 
+    property int localDomeTemp: 0
+    property int localStoneTemp: 0
+
     Timer {
         id: displayUpdateTimer
         interval: 1000
         repeat: true
         running: !demoModeIsActive
         onTriggered: {
+            console.log("Preheat timer: upperTemp = " + upperFront.setTemp + ", lowerTemp = " + lowerFront.setTemp);
             var currentDisplayTemp = upperTemp;
             var currentActualTemp = (upperFront.currentTemp < upperRear.currentTemp) ? upperFront.currentTemp : upperRear.currentTemp;
             if (!rootWindow.originalConfiguration) {
@@ -156,6 +160,9 @@ Item {
         }
 
         ovenStateCount = 3;
+
+        localDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
+        localStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
     }
 
     function cleanUpOnExit() {
@@ -219,9 +226,9 @@ Item {
     CircleContentTwoTemp {
         id: circleContent
         needsAnimation: true
-        line1String: utility.tempToString(upperFront.setTemp)
+        line1String: utility.tempToString(localDomeTemp)
         line2String: domeToggle.state ? utility.tempToString(upperTemp) : "OFF"
-        line3String: utility.tempToString(lowerFront.setTemp)
+        line3String: utility.tempToString(localStoneTemp)
         line4String: utility.tempToString(lowerTemp)
         onTopStringClicked: {
             startExitToScreen("Screen_EnterDomeTemp.qml");

--- a/PizzaOvenUI/Screen_Preheating2Temp.qml
+++ b/PizzaOvenUI/Screen_Preheating2Temp.qml
@@ -161,8 +161,8 @@ Item {
 
         ovenStateCount = 3;
 
-        localDomeTemp = menuSettings.json.menuItems[foodIndex].domeTemp;
-        localStoneTemp = menuSettings.json.menuItems[foodIndex].stoneTemp;
+        localDomeTemp = rootWindow.displayedDomeTemp;
+        localStoneTemp = rootWindow.displayedStoneTemp;
     }
 
     function cleanUpOnExit() {

--- a/PizzaOvenUI/Utility.qml
+++ b/PizzaOvenUI/Utility.qml
@@ -88,9 +88,8 @@ Item {
                 return;
             }
         }
-        console.log("No match found, setting the food index to 4 and save these new settings as custom.");
+        console.log("No match found, setting the food index to 4.");
         rootWindow.foodIndex = 4;
-        saveCurrentSettingsAsCustom();
     }
 
     function updateReminderSettingsOnBackend() {

--- a/PizzaOvenUI/Utility.qml
+++ b/PizzaOvenUI/Utility.qml
@@ -77,16 +77,20 @@ Item {
         var menuItems = menuSettings.json.menuItems;
 
         console.log("In findPizzaTypeFromSettings.");
+        console.log("Requested settings - dome: " + dome + ", stone: " + stone + ", time: " + cookTime);
 
+        console.log("Searching cycles for a match.");
         for(var i=0; i<menuItems.length; i++)  {
+            console.log("name: " + menuItems[i].name + ", dome: " + menuItems[i].domeTemp + ", stone: " + menuItems[i].stoneTemp + ", time: " + menuItems[i].cookTime);
             if (menuItems[i].domeTemp == dome && menuItems[i].stoneTemp == stone && cookTime == menuItems[i].cookTime) {
                 console.log("Found matching settings, setting the food index to " + i);
                 rootWindow.foodIndex = i;
                 return;
             }
         }
-        console.log("No match found, setting the food index to 4");
+        console.log("No match found, setting the food index to 4 and save these new settings as custom.");
         rootWindow.foodIndex = 4;
+        saveCurrentSettingsAsCustom();
     }
 
     function updateReminderSettingsOnBackend() {

--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -165,7 +165,7 @@ Window {
 
     // some information
     property string controlVersion: "255.255.255.255"
-    property string uiVersion: originalConfiguration ? "0.3.7" : "20.0.7"
+    property string uiVersion: originalConfiguration ? "0.3.8" : "20.0.8"
     property string backendVersion: "255.255.255.255"
     property string interfaceVersion: "255.255.255.255"
     property string wifiMacId: ""

--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -301,7 +301,8 @@ Window {
 
         if (currentScreen === newScreenName)
         {
-            console.log("Transition to same screen, so don't switch.")
+            console.log("Transition to same screen, so don't switch. Attempt to update the screen.")
+            stackView.currentItem.update();
             return;
         }
 


### PR DESCRIPTION
**Description:**
See https://github.com/FirstBuild/PizzaOvenOther/issues/5. 

There were a couple issues going on:
1. For gen 2, the cycle temps and times have changes slightly and the app was hard coded to the gen 1 temps/times. Thus, when the app started the cycles, the UI looked up the cycle by temp/time and could not find a match. This caused it to load the 'custom' cycle.
2. When the UI was displaying the waiting to start screen for a selected cycle, loading a new cycle from the app would update the label but not the temp/times.
3. Whenever a custom cycle is loaded from the app, the settings where not stored to the custom cycle settings. Thus, each time custom is loaded from the app, it would display the settings from the json file, not the settings specified by the app.

**Fixes:**
1. When @BobbyLindsey's PR is completed to allow the mobile app to use the cycle settings file (instead of hard coding), this will be completely fixed. For now, only the 'Roasted Vegetables', 'Roasted Fruit' and 'White Fish' cycles work since the temps/times have not changed since Gen 1. 
2. Added an "Update()" function to the `Screen_AwaitStart.qml` screen. This new update function is called whenever the screen is already loaded whereas before the new settings were just ignored.
3. Any time a custom cycle is loaded from the app, the custom settings are stored to the `menuSettings` json file (exact same behavior as if the custom cycle is modified from the oven UI).

**Testing:**
- Bench tested. More extensive testing to be performed on the oven as part of targeted field test.

Fixes: https://github.com/FirstBuild/PizzaOvenOther/issues/5
