### PR TITLE
Bug Fix - Preheat screen dome/stone temps

### DIFF
--- a/PizzaOvenUI/Screen_Preheating2Temp.qml
+++ b/PizzaOvenUI/Screen_Preheating2Temp.qml
@@ -35,9 +35,6 @@ Item {
 
     property string localOvenState: "Preheat1"
 
-    property int localDomeTemp: 0
-    property int localStoneTemp: 0
-
     Timer {
         id: displayUpdateTimer
         interval: 1000
@@ -161,8 +158,8 @@ Item {
 
         ovenStateCount = 3;
 
-        localDomeTemp = rootWindow.displayedDomeTemp;
-        localStoneTemp = rootWindow.displayedStoneTemp;
+        rootWindow.displayedDomeTemp = upperFront.setTemp;
+        rootWindow.displayedStoneTemp = lowerFront.setTemp;
     }
 
     function cleanUpOnExit() {
@@ -226,9 +223,9 @@ Item {
     CircleContentTwoTemp {
         id: circleContent
         needsAnimation: true
-        line1String: utility.tempToString(localDomeTemp)
+        line1String: utility.tempToString(upperFront.setTemp)
         line2String: domeToggle.state ? utility.tempToString(upperTemp) : "OFF"
-        line3String: utility.tempToString(localStoneTemp)
+        line3String: utility.tempToString(lowerFront.setTemp)
         line4String: utility.tempToString(lowerTemp)
         onTopStringClicked: {
             startExitToScreen("Screen_EnterDomeTemp.qml");

--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -165,7 +165,7 @@ Window {
 
     // some information
     property string controlVersion: "255.255.255.255"
-    property string uiVersion: originalConfiguration ? "0.3.8" : "20.0.8"
+    property string uiVersion: originalConfiguration ? "0.3.9" : "20.0.9"
     property string backendVersion: "255.255.255.255"
     property string interfaceVersion: "255.255.255.255"
     property string wifiMacId: ""


### PR DESCRIPTION
**Background:**
During preheat, if the user changes the dome or stone temp, the value does not change on the preheat screen. It stays latched to the value at the time preheat was started.

**Fix:**
Use the actual set temperature values instead of local variables for the preheat screen's temperature fields.

**Testing:**
- [x] Confirm this works on a real unit. I've only confirmed it on a simulator.
- [x] Make sure the preheat screen displays the correct values when setting up a cycle from the mobile app.