### PR TITLE
Remove unusable control lockout setting

### DIFF
--- a/PizzaOvenUI/Screen_Settings2.qml
+++ b/PizzaOvenUI/Screen_Settings2.qml
@@ -79,7 +79,6 @@ Item {
         id: settingsModel
         ListElement { name: "CHECK FOOD REMINDERS"; screen: "Screen_EnterChecks.qml" }
         ListElement { name: "PREFERENCES"; screen: "Screen_Preferences.qml" }
-        ListElement { name: "CONTROL LOCKOUT" }
         ListElement { name: "VOLUME"; screen: "Screen_SetVolume.qml" }
         ListElement { name: "DISPLAY BRIGHTNESS"; screen: "Screen_SetBrightness.qml" }
         ListElement { name: "ABOUT"; screen: "Screen_About.qml" }

--- a/PizzaOvenUI/main.qml
+++ b/PizzaOvenUI/main.qml
@@ -165,7 +165,7 @@ Window {
 
     // some information
     property string controlVersion: "255.255.255.255"
-    property string uiVersion: originalConfiguration ? "0.3.9" : "20.0.9"
+    property string uiVersion: originalConfiguration ? "0.3.10" : "20.0.10"
     property string backendVersion: "255.255.255.255"
     property string interfaceVersion: "255.255.255.255"
     property string wifiMacId: ""


### PR DESCRIPTION
Found a "dead" setting for control lockout. It doesn't do anything.